### PR TITLE
Добавляется функциональность - данные не удаляются

### DIFF
--- a/src/main/java/ru/netology/controller/PostController.java
+++ b/src/main/java/ru/netology/controller/PostController.java
@@ -31,6 +31,7 @@ public class PostController {
     }
 
     @DeleteMapping("/{id}")
+
     public void removeById(@PathVariable long id) {
         service.removeById(id);
     }

--- a/src/main/java/ru/netology/exception/NotFoundException.java
+++ b/src/main/java/ru/netology/exception/NotFoundException.java
@@ -1,5 +1,9 @@
 package ru.netology.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class NotFoundException extends RuntimeException {
     public NotFoundException() {
     }

--- a/src/main/java/ru/netology/model/Post.java
+++ b/src/main/java/ru/netology/model/Post.java
@@ -3,6 +3,7 @@ package ru.netology.model;
 public class Post {
     private long id;
     private String content;
+    private boolean removed;
 
     public Post() {
     }
@@ -10,6 +11,7 @@ public class Post {
     public Post(long id, String content) {
         this.id = id;
         this.content = content;
+        removed = false;
     }
 
     public long getId() {
@@ -26,5 +28,13 @@ public class Post {
 
     public void setContent(String content) {
         this.content = content;
+    }
+
+    public boolean isRemoved() {
+        return removed;
+    }
+
+    public void setRemoved(boolean removed) {
+        this.removed = removed;
     }
 }

--- a/src/main/java/ru/netology/repository/PostRepositoryStubImpl.java
+++ b/src/main/java/ru/netology/repository/PostRepositoryStubImpl.java
@@ -1,6 +1,7 @@
 package ru.netology.repository;
 
 import org.springframework.stereotype.Repository;
+import ru.netology.exception.NotFoundException;
 import ru.netology.model.Post;
 
 import java.util.ArrayList;
@@ -14,12 +15,21 @@ public class PostRepositoryStubImpl implements PostRepository {
     private AtomicLong count = new AtomicLong(0);
 
     public List<Post> all() {
-        return posts;
+        List<Post> postsNotRemoved = new ArrayList<>();
+        for (Post element : posts) {
+            if (!element.isRemoved()) {
+                postsNotRemoved.add(element);
+            }
+        }
+        return postsNotRemoved;
     }
 
     public Optional<Post> getById(long id) {
         for (Post element : posts) {
             if (element.getId() == id) {
+                if (element.isRemoved()) {
+                    throw new NotFoundException();
+                }
                 return Optional.of(element);
             }
         }
@@ -30,6 +40,9 @@ public class PostRepositoryStubImpl implements PostRepository {
         if (post.getId() != 0) {
             for (Post element : posts) {
                 if (element.getId() == post.getId()) {
+                    if (element.isRemoved()) {
+                        throw new NotFoundException();
+                    }
                     return post;
                 }
             }
@@ -41,9 +54,9 @@ public class PostRepositoryStubImpl implements PostRepository {
     }
 
     public void removeById(long id) {
-        for (Post element : posts) {
-            if (element.getId() == id) {
-                posts.remove(element);
+        for (Post post : posts) {
+            if (post.getId() == id) {
+                post.setRemoved(true);
                 break;
             }
         }


### PR DESCRIPTION
Здравствуйте!
Добавилась следующая функциональность, когда клиент посылает запрос на удаление поста, пост не удаляется, а помечается как removed. Метод all возвращает все посты кроме removed. Метод getById возвращает пост, если он не removed, аналогично метод save. Это реализовано в репозитории, так как по определению контролер отвечает за внешние связи, а сервис - за бизнес-логику. Примерно так.
До связи, жду оценку.